### PR TITLE
Support unlimited dimensions if number of obs or locations are unkown

### DIFF
--- a/pynetcf/base.py
+++ b/pynetcf/base.py
@@ -6,13 +6,13 @@
 # modification, are permitted provided that the following conditions are met:
 #   * Redistributions of source code must retain the above copyright
 #     notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above copyright
-#      notice, this list of conditions and the following disclaimer in the
-#      documentation and/or other materials provided with the distribution.
-#    * Neither the name of the Vienna University of Technology,
-#      Department of Geodesy and Geoinformation nor the
-#      names of its contributors may be used to endorse or promote products
-#      derived from this software without specific prior written permission.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Vienna University of Technology,
+#     Department of Geodesy and Geoinformation nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/pynetcf/time_series.py
+++ b/pynetcf/time_series.py
@@ -590,10 +590,8 @@ class OrthoMultiTs(Dataset):
         if direct:
             self.append_var(self.time_var, dates)
         else:
-            self.append_var(self.time_var,
-                            netCDF4.date2num(dates,
-                                             units=self.dataset.variables[
-                                                 self.time_var].units,
+            units = self.dataset.variables[self.time_var].units
+            self.append_var(self.time_var, netCDF4.date2num(dates, units=units,
                                              calendar='standard'))
 
     def write_ts(self, loc_id, data, dates, extend_time='first',

--- a/pynetcf/time_series.py
+++ b/pynetcf/time_series.py
@@ -1052,7 +1052,7 @@ class IndexedRaggedTs(ContiguousRaggedTs):
             if location id could not be found
         """
         try:
-            loc_ix = self._get_loc_index(loc_id)
+            loc_ix = self._get_loc_id_index(loc_id)
         except IOError:
             msg = "".join(("Time series for Location #", loc_id.__str__(),
                            " not found."))
@@ -1106,7 +1106,7 @@ class IndexedRaggedTs(ContiguousRaggedTs):
             point number of correct magnitude
         """
         try:
-            idx = self._get_loc_index(loc_id)
+            idx = self._get_loc_id_index(loc_id)
         except IOError:
             idx = self._add_location(loc_id, lon, lat, alt, loc_descr)
 

--- a/pynetcf/time_series.py
+++ b/pynetcf/time_series.py
@@ -127,7 +127,8 @@ class OrthoMultiTs(Dataset):
 
         # initialize dimensions and index_variable
         if self.mode == 'w':
-            self._init_dimensions_and_lookup()
+            self._init_dimensions()
+            self._init_lookup()
             self._init_location_variables()
             self._init_location_id_and_time()
 
@@ -154,35 +155,24 @@ class OrthoMultiTs(Dataset):
         else:
             self.variables = {}
 
-    def _init_dimensions_and_lookup(self):
+    def _init_dimensions(self):
         """
-        Initializes the dimensions and variables for the lookup
-        between locations and entries in the time series
+        Initializes the dimensions.
         """
         if self.n_loc is None:
-            raise ValueError('Number of locations '
-                             'have to be set for new file')
+            raise ValueError('Number of locations have to be set for'
+                             'new OrthoMultiTs file')
 
         self.create_dim(self.loc_dim_name, self.n_loc)
         self.create_dim(self.obs_dim_name, None)
 
-    def _init_location_id_and_time(self):
+    def _init_lookup(self):
         """
-        initialize the dimensions and variables that are the basis of
-        the format
+        Initializes variables for the lookup between locations and entries in
+        the time series.
         """
-        # make variable that contains the location id
-        self.write_var(self.loc_ids_name, data=None, dim=self.loc_dim_name,
-                       dtype=np.int)
-        self.write_var(self.loc_descr_name, data=None, dim=self.loc_dim_name,
-                       dtype='str')
-        # initialize time variable
-        self.write_var(self.time_var, data=None, dim=self.obs_dim_name,
-                       attr={'standard_name': 'time',
-                             'long_name': 'time of measurement',
-                             'units': self.time_units},
-                       dtype=np.double,
-                       chunksizes=self.unlim_chunksize)
+        # nothing to be done for OrthoMultiTs
+        pass
 
     def _init_location_variables(self):
         # write station information, longitude, latitude and altitude
@@ -789,26 +779,24 @@ class ContiguousRaggedTs(OrthoMultiTs):
 
         super(ContiguousRaggedTs, self).__init__(filename, n_loc=n_loc,
                                                  obs_dim_name=obs_dim_name,
-                                                 ** kwargs)
+                                                 **kwargs)
         self.constant_dates = False
 
-    def _init_dimensions_and_lookup(self):
+    def _init_dimensions(self):
         """
-        Initializes the dimensions and variables for the lookup
-        between locations and entries in the time series
+        Initializes the dimensions.
         """
-        if self.n_loc is None:
-            raise ValueError('Number of locations '
-                             'have to be set for new file')
-        if self.n_obs is None:
-            raise ValueError('Number of observations have '
-                             'to be set for new file')
-
         self.create_dim(self.loc_dim_name, self.n_loc)
         self.create_dim(self.obs_dim_name, self.n_obs)
 
+    def _init_lookup(self):
+        """
+        Initializes variables for the lookup between locations and entries in
+        the time series.
+        """
         attr = {'long_name': 'number of observations at this location',
                 'sample_dimension': self.obs_dim_name}
+
         self.write_var(self.obs_loc_lut, data=None, dim=self.loc_dim_name,
                        dtype=np.int, attr=attr,
                        chunksizes=self.unlim_chunksize)
@@ -954,19 +942,14 @@ class IndexedRaggedTs(ContiguousRaggedTs):
         self.not_timeseries.append(self.obs_loc_lut)
         self.constant_dates = False
 
-    def _init_dimensions_and_lookup(self):
+    def _init_lookup(self):
         """
-        Initializes the dimensions and variables for the lookup
-        between locations and entries in the time series
+        Initializes variables for the lookup between locations and entries
+        in the time series.
         """
-        if self.n_loc is None:
-            raise ValueError('Number of locations '
-                             'have to be set for new file')
-
-        self.create_dim(self.loc_dim_name, self.n_loc)
-        self.create_dim(self.obs_dim_name, self.n_obs)
         attr = {'long_name': 'which location this observation is for',
                 'instance_dimension': self.loc_dim_name}
+
         self.write_var(self.obs_loc_lut, data=None, dim=self.obs_dim_name,
                        dtype=np.int, attr=attr,
                        chunksizes=self.unlim_chunksize)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 netCDF4
 pytesmo>=0.2.4
+pygeobase

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -2,21 +2,18 @@
 Testing time series classes of pynetcf.
 """
 
+
 import os
 import unittest
-import pandas as pd
+from tempfile import mkdtemp
 
+import pandas as pd
 from datetime import datetime, timedelta
 import numpy as np
 import numpy.testing as nptest
 
 import pynetcf.time_series as nc
 import pytesmo.grid.grids as grids
-
-
-def curpath():
-    pth, _ = os.path.split(os.path.abspath(__file__))
-    return pth
 
 import sys
 if sys.version_info < (3, 0):
@@ -26,7 +23,7 @@ if sys.version_info < (3, 0):
 class OrthoMultiTest(unittest.TestCase):
 
     def setUp(self):
-        self.testfilename = os.path.join(curpath(), 'data', 'test.nc')
+        self.testfilename = os.path.join(mkdtemp(), 'test.nc')
 
     def tearDown(self):
         os.remove(self.testfilename)
@@ -244,7 +241,7 @@ class OrthoMultiTest(unittest.TestCase):
 class DatasetContiguousTest(unittest.TestCase):
 
     def setUp(self):
-        self.testfilename = os.path.join(curpath(), 'data', 'test.nc')
+        self.testfilename = os.path.join(mkdtemp(), 'test.nc')
 
     def tearDown(self):
         os.remove(self.testfilename)
@@ -276,7 +273,7 @@ class DatasetContiguousTest(unittest.TestCase):
 class DatasetIndexedTest(unittest.TestCase):
 
     def setUp(self):
-        self.testfilename = os.path.join(curpath(), 'data', 'test.nc')
+        self.testfilename = os.path.join(mkdtemp(), 'test.nc')
 
     def tearDown(self):
         os.remove(self.testfilename)
@@ -349,7 +346,7 @@ class DatasetIndexedTest(unittest.TestCase):
 class DatasetGriddedTsTests(unittest.TestCase):
 
     def setUp(self):
-        self.testdatapath = os.path.join(curpath(), 'data', '')
+        self.testdatapath = os.path.join(mkdtemp())
         self.testfilename = os.path.join(self.testdatapath, '0107.nc')
         self.grid = grids.genreg_grid().to_cell_grid()
 

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -22,6 +22,7 @@ import sys
 if sys.version_info < (3, 0):
     range = xrange
 
+
 class OrthoMultiTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1,7 +1,34 @@
+# Copyright (c) 2015, Vienna University of Technology,
+# Department of Geodesy and Geoinformation
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Vienna University of Technology,
+#     Department of Geodesy and Geoinformation nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL VIENNA UNIVERSITY OF TECHNOLOGY,
+# DEPARTMENT OF GEODESY AND GEOINFORMATION BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 """
 Testing time series classes of pynetcf.
 """
-
 
 import os
 import unittest


### PR DESCRIPTION
Add feature to support unlimited dimensions if number of obs or locations are unkown for ` ContiguousRaggedTs` and `IndexedRaggedTs` .

The feature also implements a new class `GriddedNcTs`, which is a subclass of the base classed provided by pygeobase. The old class `GriddedTs` has not been changed in order to maintain backwards compatibility.