### PR TITLE
Fix read_bulk keyword for Contigous and Indexed Ragged classes

### DIFF
--- a/pynetcf/time_series.py
+++ b/pynetcf/time_series.py
@@ -149,7 +149,10 @@ class OrthoMultiTs(Dataset):
         self.constant_dates = True
         self.dates = None
         self.read_dates_auto = read_dates
-        self.read_bulk = read_bulk
+        if self.mode == 'r':
+            self.read_bulk = read_bulk
+        else:
+            self.read_bulk = False
 
         # cache location id during reading
         self.prev_loc_id = None
@@ -922,6 +925,9 @@ class ContiguousRaggedTs(OrthoMultiTs):
             raise ValueError("Index of time series for "
                              "location id #{:} not found".format(loc_id))
 
+        if self.read_bulk and self.obs_loc_lut not in self.variables:
+            self.variables[self.obs_loc_lut] = self.dataset.variables[
+                self.obs_loc_lut][:]
         start = np.sum(self.variables[self.obs_loc_lut][:loc_id_index])
         end = np.sum(self.variables[self.obs_loc_lut][:loc_id_index + 1])
 
@@ -1080,6 +1086,9 @@ class IndexedRaggedTs(ContiguousRaggedTs):
                            " not found."))
             raise IOError(msg)
 
+        if self.read_bulk and self.obs_loc_lut not in self.variables:
+            self.variables[self.obs_loc_lut] = self.dataset.variables[
+                self.obs_loc_lut][:]
         index = np.where(self.variables[self.obs_loc_lut] == loc_ix)[0]
 
         if len(index) == 0:

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -470,7 +470,7 @@ class DatasetGriddedTsTests(unittest.TestCase):
             nptest.assert_array_equal(ts['var1'], np.arange(len(dates)))
             nptest.assert_array_equal(ts['var2'], np.arange(len(dates)))
 
-    def _test_writing_with_attributes_prepared_classes(self, ioclass):
+    def _test_writing_with_attributes_prepared_classes(self, ioclass, read_bulk=False):
 
         dates = pd.date_range(start='2007-01-01', end='2007-02-01')
 
@@ -480,15 +480,18 @@ class DatasetGriddedTsTests(unittest.TestCase):
         attributes = {'var1': {'testattribute': 'teststring'},
                       'var2': {'testattribute2': 'teststring2'}}
 
-        dataset = ioclass(self.testdatapath, self.grid, mode='w')
+        dataset = ioclass(self.testdatapath, self.grid,
+                          mode='w', ioclass_kws={"read_bulk": read_bulk})
         for gpi in [10, 11, 12]:
             dataset.write(gpi, ts, attributes=attributes)
 
-        dataset = ioclass(self.testdatapath, self.grid, mode='a')
+        dataset = ioclass(self.testdatapath, self.grid,
+                          mode='a', ioclass_kws={"read_bulk": read_bulk})
         for gpi in [13, 10]:
             dataset.write(gpi, ts)
 
-        dataset = ioclass(self.testdatapath, self.grid, mode='r')
+        dataset = ioclass(self.testdatapath, self.grid,
+                          mode='r', ioclass_kws={"read_bulk": read_bulk})
         for gpi in [11, 12]:
             ts = dataset.read(gpi)
             nptest.assert_array_equal(ts['var1'], np.arange(len(dates)))
@@ -508,6 +511,18 @@ class DatasetGriddedTsTests(unittest.TestCase):
     def test_writing_with_attributes_GriddedOrthoMulti(self):
         self._test_writing_with_attributes_prepared_classes(
             nc.GriddedNcOrthoMultiTs)
+
+    def test_writing_with_attributes_GriddedContigious_read_bulk(self):
+        self._test_writing_with_attributes_prepared_classes(
+            nc.GriddedNcContiguousRaggedTs, read_bulk=True)
+
+    def test_writing_with_attributes_GriddedIndexed_read_bulk(self):
+        self._test_writing_with_attributes_prepared_classes(
+            nc.GriddedNcIndexedRaggedTs, read_bulk=True)
+
+    def test_writing_with_attributes_GriddedOrthoMulti_read_bulk(self):
+        self._test_writing_with_attributes_prepared_classes(
+            nc.GriddedNcOrthoMultiTs, read_bulk=True)
 
     def test_rw_dates_direct(self):
 


### PR DESCRIPTION
- only enable read_bulk in read mode. In append or write mode it is not
guaranteed that the local copy remains in sync with the netCDF4 object