### PR TITLE
Raise IOError if a location id is not in the file.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+## v0.1.14 - unreleased
+
+- fix bug that read the wrong timeseries if a non existing location id was given.
+
 ## v0.1.13 - 2017-05-02
 
 - Catch RuntimeError and IOError to be compatible with older netCDF4 versions.

--- a/pynetcf/time_series.py
+++ b/pynetcf/time_series.py
@@ -290,6 +290,11 @@ class OrthoMultiTs(Dataset):
         """
         self._read_loc_ids()
         loc_id = np.atleast_1d(loc_id)
+        # check if the location ids are all actually in the location id
+        # variable
+        in1d = np.in1d(loc_id, self.loc_ids_var.data, assume_unique=True)
+        if loc_id[in1d].size != loc_id.size:
+            raise IOError("Location not yet defined")
         loc_ids_sorted = np.argsort(self.loc_ids_var.data)
         ypos = np.searchsorted(self.loc_ids_var[loc_ids_sorted], loc_id)
         try:


### PR DESCRIPTION
Before np.searchsorted just returned the indices where the new gpi should go
which meant that a wrong timeseries was returned.