### PR TITLE
More robust lon/lat initialization for imagestack

### DIFF
--- a/pynetcf/image.py
+++ b/pynetcf/image.py
@@ -175,8 +175,8 @@ class ImageStack(Dataset):
             self._load_variables()
 
     def _init_dimensions(self):
-        self.create_dim('lon', self.grid.lon2d.shape[0])
-        self.create_dim('lat', self.grid.lat2d.shape[1])
+        self.create_dim('lon', np.unique(self.grid.lon2d).__len__())
+        self.create_dim('lat', np.unique(self.grid.lat2d).__len__())
         self.create_dim('time', len(self.times))
 
     def _load_grid(self):
@@ -209,13 +209,13 @@ class ImageStack(Dataset):
 
     def _init_location_variables(self):
         # write station information, longitude, latitude and altitude
-        self.write_var('lon', data=self.grid.lon2d[:, 0], dim='lon',
+        self.write_var('lon', data=snp.sort(np.unique(self.grid.lon2d)), dim='lon',
                        attr={'standard_name': 'longitude',
                              'long_name': 'location longitude',
                              'units': 'degrees_east',
                              'valid_range': (-180.0, 180.0)},
                        dtype=np.float)
-        self.write_var('lat', data=self.grid.lat2d[0, :], dim='lat',
+        self.write_var('lat', data=np.sort(np.unique(self.grid.lat2d)), dim='lat',
                        attr={'standard_name': 'latitude',
                              'long_name': 'location latitude',
                              'units': 'degrees_north',

--- a/pynetcf/image.py
+++ b/pynetcf/image.py
@@ -209,7 +209,7 @@ class ImageStack(Dataset):
 
     def _init_location_variables(self):
         # write station information, longitude, latitude and altitude
-        self.write_var('lon', data=snp.sort(np.unique(self.grid.lon2d)), dim='lon',
+        self.write_var('lon', data=np.sort(np.unique(self.grid.lon2d)), dim='lon',
                        attr={'standard_name': 'longitude',
                              'long_name': 'location longitude',
                              'units': 'degrees_east',

--- a/pynetcf/image.py
+++ b/pynetcf/image.py
@@ -209,13 +209,13 @@ class ImageStack(Dataset):
 
     def _init_location_variables(self):
         # write station information, longitude, latitude and altitude
-        self.write_var('lon', data=np.sort(np.unique(self.grid.lon2d)), dim='lon',
+        self.write_var('lon', data=np.unique(self.grid.lon2d), dim='lon',
                        attr={'standard_name': 'longitude',
                              'long_name': 'location longitude',
                              'units': 'degrees_east',
                              'valid_range': (-180.0, 180.0)},
                        dtype=np.float)
-        self.write_var('lat', data=np.sort(np.unique(self.grid.lat2d)), dim='lat',
+        self.write_var('lat', data=np.unique(self.grid.lat2d), dim='lat',
                        attr={'standard_name': 'latitude',
                              'long_name': 'location latitude',
                              'units': 'degrees_north',

--- a/pynetcf/image.py
+++ b/pynetcf/image.py
@@ -215,7 +215,7 @@ class ImageStack(Dataset):
                              'units': 'degrees_east',
                              'valid_range': (-180.0, 180.0)},
                        dtype=np.float)
-        self.write_var('lat', data=np.unique(self.grid.lat2d), dim='lat',
+        self.write_var('lat', data=np.unique(self.grid.lat2d)[::-1], dim='lat',
                        attr={'standard_name': 'latitude',
                              'long_name': 'location latitude',
                              'units': 'degrees_north',


### PR DESCRIPTION
The current lon/lat initialization  of `ImageStack` can break if the grid has an unusual row/col arrangement or an unusual shape. E.g. if you create an imagestack with this grid all grid points will have the same lat and lon.:

```
import pygeogrids.grids as grids
from pynetcf.image import ImageStack
import pandas as pd

grid = grids.genreg_grid(0.25, 0.25)
filename = '/data-write/RADAR/vod_merged/v01.0/tests/sdasa.nc'
times = pd.date_range('2000', '2001', freq='M').to_pydatetime()
ds = ImageStack(filename, grid=grid, times=times, mode='w')
print ds.dataset.variables['lon'][:]
# all lons are -179.875
```

The proposed change uses `np.unique()` to get the lat/lon values, which works independent of the grids orientation.
I ran the already in place tests with the changes and broke none of them, but it still might now screw up some other grid.