### PR TITLE
Add a destructor for Dataset

### DIFF
--- a/src/pynetcf/base.py
+++ b/src/pynetcf/base.py
@@ -290,3 +290,7 @@ class Dataset(object):
 
     def __exit__(self, value_type, value, traceback):
         self.close()
+        
+    def __del__(self):
+        if hasattr(self, "dataset"):
+            self.close()


### PR DESCRIPTION
@wpreimes solved issue #57 by adding a call to `.close`. Would it be possible to add a destructor/finalizer that makes sure that the netcdf dataset is closed when the `pynetcf.Dataset` is destroyed? The proposed change also makes the other mentioned problem run smoothly.