### PR TITLE
Single cell bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 
 Unreleased changes in master branch
 ===================================
--
+
+- Fixed a bug where the previous cell from the reader was not cleared properly. This caused empty data when a previous attempt failed.
 
 
 Version 0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
 - pip:
   - pygeobase
   - pygeogrids
+  - pytest-cov

--- a/src/pynetcf/time_series.py
+++ b/src/pynetcf/time_series.py
@@ -1587,6 +1587,7 @@ class GriddedNcTs(GriddedTsBase):
                 except (IOError, RuntimeError):
                     success = False
                     self.fid = None
+                    self.previous_cell = None
                     warnings.warn(f"I/O error {filename}", RuntimeWarning)
 
         if self.mode in ["w", "a"]:
@@ -1607,6 +1608,7 @@ class GriddedNcTs(GriddedTsBase):
                 except (IOError, RuntimeError):
                     success = False
                     self.fid = None
+                    self.previous_cell = None
                     warnings.warn(f"I/O error {filename}", RuntimeWarning)
 
         return success


### PR DESCRIPTION
When processing a single cell in a directory (e.g.: testing `ascat_resampling` with a single .nc file), the processing fails, if the `previous_cell` was not reset to None. This has been changed and now after every failed attempt the `previous_cell` is cleared.
Pytests are added in the env.yml
